### PR TITLE
feat(auth): added initial impl of auth service

### DIFF
--- a/.github/workflows/deploy-template.yml
+++ b/.github/workflows/deploy-template.yml
@@ -43,9 +43,13 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Deploy with Wrangler${{ inputs.noop && ' (dry run)' || '' }}
         uses: cloudflare/wrangler-action@v3
+        env:
+          JWT_TOKEN: ${{ secrets.JWT_TOKEN }}
         with:
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           command: deploy${{ inputs.noop && ' --dry-run' || '' }}
           environment: ${{ inputs.noop && '' || inputs.environment }}
+          secrets: |
+            JWT_TOKEN
           wranglerVersion: ${{ steps.wrangler-version.outputs.version }}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "configurations": [
+    {
+      "name": "Attach to Wrangler",
+      "port": 9229,
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -36,15 +36,21 @@
     "format:fix:yml": "prettier -w \"**/*.yml\""
   },
   "dependencies": {
+    "@tsndr/cloudflare-worker-jwt": "^2.2.5",
+    "bcryptjs": "^2.4.3",
     "concurrently": "^8.2.2",
-    "itty-router": "^4.0.23"
+    "itty-router": "^4.0.23",
+    "ms": "^2.1.3",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20231025.0",
     "@commitlint/cli": "^18.2.0",
     "@commitlint/config-conventional": "^18.1.0",
     "@ianvs/prettier-plugin-sort-imports": "^4.1.1",
+    "@types/bcryptjs": "^2.4.5",
     "@types/eslint": "^8.44.6",
+    "@types/ms": "^0.7.33",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "eslint": "^8.52.0",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,10 @@
+import { authRouter } from "./auth/router";
+import { usersRouter } from "./users/router";
+import { createRouter } from "./utils/router";
+
+const router = createRouter({ base: "/api/v1" });
+
+router.all("/auth/*", authRouter.handle);
+router.all("/users/*", usersRouter.handle);
+
+export { router as routerV1 };

--- a/src/auth/login.ts
+++ b/src/auth/login.ts
@@ -1,0 +1,19 @@
+import { StatusError } from "itty-router";
+
+import { LoginRequest, User } from "../models/user";
+import { HashingService } from "../services/hashing";
+
+export async function login(db: KVNamespace, hasher: HashingService, req: LoginRequest): Promise<User> {
+  const data = await db.get(req.email);
+  if (!data) {
+    throw new StatusError(401, "Invalid email or password");
+  }
+  const user = User.parse(JSON.parse(data));
+
+  const isValid = await hasher.compare(req.password, user.password);
+  if (!isValid) {
+    throw new StatusError(401, "Invalid email or password");
+  }
+
+  return user;
+}

--- a/src/auth/middleware.ts
+++ b/src/auth/middleware.ts
@@ -1,0 +1,39 @@
+import { StatusError } from "itty-router";
+
+import { User } from "../models/user";
+import { JwtError } from "../services/jwt";
+import { AppMiddleware } from "../utils/router";
+
+export const authMiddleware: AppMiddleware = async (request, env) => {
+  const header = request.headers.get("authorization");
+  if (!header || !header.startsWith("Bearer ")) {
+    throw new StatusError(401, "No credentials were provided");
+  }
+
+  const token = header.split(" ")[1];
+  let isValid: boolean;
+  try {
+    isValid = await env.jwt.verify(token);
+  } catch (error) {
+    if (error instanceof JwtError) {
+      throw new StatusError(400, error.message);
+    }
+    throw error;
+  }
+  if (!isValid) {
+    throw new StatusError(401, "Invalid JWT");
+  }
+
+  const { email } = env.jwt.decode(token);
+  if (!email) {
+    throw new StatusError(401, "Invalid JWT");
+  }
+
+  const data = await env.users.get(email);
+  if (!data) {
+    throw new StatusError(401, "The user associated with this token doesn't exist");
+  }
+
+  const user = User.parse(JSON.parse(data));
+  request.user = user;
+};

--- a/src/auth/register.ts
+++ b/src/auth/register.ts
@@ -1,0 +1,27 @@
+import { StatusError } from "itty-router";
+
+import { RegisterRequest, User } from "../models/user";
+import { HashingService } from "../services/hashing";
+
+export async function register(db: KVNamespace, hasher: HashingService, req: RegisterRequest): Promise<User> {
+  const possibleDuplicate = await db.get(req.email);
+  if (possibleDuplicate) {
+    throw new StatusError(400, "Another user already exists with that email");
+  }
+
+  const id = crypto.randomUUID();
+  const password = await hasher.hash(req.password);
+
+  const now = new Date();
+  const user: User = {
+    ...req,
+    id,
+    password,
+    createdAt: now,
+    updatedAt: now,
+    lastPasswordUpdate: now,
+  };
+
+  await db.put(req.email, JSON.stringify(user));
+  return user;
+}

--- a/src/auth/router.ts
+++ b/src/auth/router.ts
@@ -1,0 +1,37 @@
+import { LoginRequest, LoginResponse, RegisterRequest, RegisterResponse, SanitizedUser } from "../models/user";
+import { parseBody } from "../utils/model-parser";
+import { createRouter } from "../utils/router";
+import { login } from "./login";
+import { register } from "./register";
+
+const router = createRouter({ base: "/api/v1/auth" });
+
+router.post("/register", async (request, env): Promise<RegisterResponse> => {
+  const req = await parseBody(request, RegisterRequest);
+
+  const user = await register(env.users, env.hasher, req);
+
+  return {
+    success: true,
+    user: SanitizedUser.parse(user),
+  };
+});
+
+router.post("/login", async (request, env): Promise<LoginResponse> => {
+  const req = await parseBody(request, LoginRequest);
+
+  const user = await login(env.users, env.hasher, req);
+
+  const token = await env.jwt.sign({
+    sub: user.id,
+    name: user.fullName,
+    email: user.email,
+  });
+
+  return {
+    jwt: token,
+    user: SanitizedUser.parse(user),
+  };
+});
+
+export { router as authRouter };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,31 @@
 import { error, json } from "itty-router";
 
-import { AppEnv, createRouter } from "./utils/router";
+import { routerV1 } from "./api";
+import { AppJwtPayload } from "./models/user";
+import { BcryptService } from "./services/bcrypt";
+import { JwtService } from "./services/jwt";
+import { AppBindings, AppEnv } from "./utils/env";
+import { createRouter } from "./utils/router";
 
 const router = createRouter();
 
-router.get("/", () => {
-  return { success: true, message: "Hello, world!" };
-});
+router.all("/api/v1/*", routerV1.handle);
+
+router.all("*", () => error(404));
 
 export default {
-  fetch(request: Request, env: AppEnv, ctx: ExecutionContext): Promise<Response> {
+  fetch(request: Request, bindings: AppBindings, ctx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+
+    const env: AppEnv = {
+      ...bindings,
+      jwt: new JwtService<AppJwtPayload>(bindings.JWT_SECRET, {
+        aud: url.hostname,
+        exp: JwtService.exp("30d"),
+      }),
+      hasher: new BcryptService(),
+    };
+
     return router.handle(request, env, ctx).then(json).catch(error);
   },
 };

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,47 @@
+import { JwtPayload } from "@tsndr/cloudflare-worker-jwt";
+import { z } from "zod";
+
+import { ZodDate } from "../utils/zod-date";
+
+export const User = z.object({
+  id: z.string().uuid(),
+  fullName: z.string().min(1),
+  preferredName: z.string().min(1),
+  email: z.string().email(),
+  password: z.string().min(8).max(72),
+  createdAt: ZodDate,
+  updatedAt: ZodDate,
+  lastPasswordUpdate: ZodDate,
+});
+export type User = z.infer<typeof User>;
+
+export const SanitizedUser = User.omit({ password: true });
+export type SanitizedUser = z.infer<typeof SanitizedUser>;
+
+export const RegisterRequest = User.pick({
+  fullName: true,
+  preferredName: true,
+  email: true,
+  password: true,
+});
+export type RegisterRequest = z.infer<typeof RegisterRequest>;
+
+export const RegisterResponse = z.object({
+  success: z.boolean(),
+  user: SanitizedUser,
+});
+export type RegisterResponse = z.infer<typeof RegisterResponse>;
+
+export const LoginRequest = User.pick({ email: true, password: true });
+export type LoginRequest = z.infer<typeof LoginRequest>;
+
+export const LoginResponse = z.object({
+  jwt: z.string(),
+  user: SanitizedUser,
+});
+export type LoginResponse = z.infer<typeof LoginResponse>;
+
+export interface AppJwtPayload extends JwtPayload {
+  name?: string;
+  email?: string;
+}

--- a/src/services/bcrypt.ts
+++ b/src/services/bcrypt.ts
@@ -1,0 +1,20 @@
+import * as bcrypt from "bcryptjs";
+
+import { HashingService } from "./hashing";
+
+export class BcryptService implements HashingService {
+  constructor(private rounds: number = 10) {}
+
+  salt(): Promise<string> {
+    return bcrypt.genSalt(this.rounds);
+  }
+
+  async hash(str: string): Promise<string> {
+    const salt = await this.salt();
+    return bcrypt.hash(str, salt);
+  }
+
+  compare(str: string, hash: string): Promise<boolean> {
+    return bcrypt.compare(str, hash);
+  }
+}

--- a/src/services/hashing.ts
+++ b/src/services/hashing.ts
@@ -1,0 +1,7 @@
+import { MaybePromise } from "../utils/types";
+
+export interface HashingService {
+  salt(): MaybePromise<string>;
+  hash(str: string): MaybePromise<string>;
+  compare(str: string, hashed: string): MaybePromise<boolean>;
+}

--- a/src/services/jwt.ts
+++ b/src/services/jwt.ts
@@ -1,0 +1,67 @@
+import * as jwt from "@tsndr/cloudflare-worker-jwt";
+import ms from "ms";
+
+import { CustomError, ErrorOptions } from "../utils/types";
+
+export class JwtError extends CustomError {
+  constructor(message?: string, options?: ErrorOptions) {
+    super("JwtError", message, options);
+  }
+}
+
+export class JwtService<TPayload extends jwt.JwtPayload> {
+  constructor(
+    private secret: string,
+    private defaultPayload?: Partial<TPayload>,
+  ) {}
+
+  private normalizeError(error: unknown): never {
+    if (error instanceof Error) {
+      throw new JwtError(error.message);
+    }
+    if (typeof error === "string") {
+      throw new JwtError(error);
+    }
+    throw error;
+  }
+
+  private createPayload(payload: TPayload): TPayload {
+    return Object.assign({}, this.defaultPayload, payload);
+  }
+
+  static exp(duration: number | string): number {
+    if (typeof duration === "string") duration = ms(duration);
+    return Math.floor(Date.now() / 1000 + duration / 1000);
+  }
+
+  exp(duration: number | string): number {
+    return JwtService.exp(duration);
+  }
+
+  async sign(payload: TPayload): Promise<string> {
+    payload = this.createPayload(payload);
+    try {
+      return await jwt.sign(payload, this.secret);
+    } catch (error) {
+      this.normalizeError(error);
+    }
+  }
+
+  async verify(token: string): Promise<boolean> {
+    try {
+      return await jwt.verify(token, this.secret);
+    } catch (error) {
+      this.normalizeError(error);
+    }
+  }
+
+  decode(token: string): TPayload {
+    try {
+      const { payload } = jwt.decode(token);
+      // TODO: Validate with Zod
+      return payload as TPayload;
+    } catch (error) {
+      this.normalizeError(error);
+    }
+  }
+}

--- a/src/users/router.ts
+++ b/src/users/router.ts
@@ -1,0 +1,10 @@
+import { SanitizedUser } from "../models/user";
+import { createAuthenticatedRouter } from "../utils/router";
+
+const router = createAuthenticatedRouter({ base: "/api/v1/users" });
+
+router.get("/me", (request): SanitizedUser => {
+  return SanitizedUser.parse(request.user);
+});
+
+export { router as usersRouter };

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,0 +1,25 @@
+import { IRequest } from "itty-router";
+
+import { AppJwtPayload, User } from "../models/user";
+import { HashingService } from "../services/hashing";
+import { JwtService } from "../services/jwt";
+
+export interface AppRequest extends IRequest {
+  user?: User;
+}
+
+export interface AuthenticatedRequest extends AppRequest {
+  user: User;
+}
+
+export interface AppBindings {
+  // Secrets
+  JWT_SECRET: string;
+  // KV
+  users: KVNamespace;
+}
+
+export interface AppEnv extends AppBindings {
+  jwt: JwtService<AppJwtPayload>;
+  hasher: HashingService;
+}

--- a/src/utils/model-parser.ts
+++ b/src/utils/model-parser.ts
@@ -1,0 +1,23 @@
+import { StatusError } from "itty-router";
+import { z, ZodTypeAny } from "zod";
+
+export const assertModel = async <T extends ZodTypeAny>(value: unknown, model: T): Promise<z.infer<T>> => {
+  const parsed = await model.safeParseAsync(value);
+  if (!parsed.success) {
+    throw new StatusError(400, parsed.error);
+  }
+  return parsed.data;
+};
+
+export const parseBody = async <T extends ZodTypeAny>(request: Request, model: T): Promise<z.infer<T>> => {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    if (error instanceof SyntaxError && error.message.includes("JSON")) {
+      throw new StatusError(400, error.message);
+    }
+    throw error;
+  }
+  return assertModel<T>(body, model);
+};

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -1,14 +1,22 @@
-import { IRequest, Router, RouterOptions } from "itty-router";
+import { RouteHandler, Router, RouterOptions } from "itty-router";
 
-export type AppRequest = {
-  // This is just defined so that the correct types in itty-router are used
-  placeholder: never;
-} & IRequest;
+import { authMiddleware } from "../auth/middleware";
+import { AppEnv, AppRequest, AuthenticatedRequest } from "./env";
 
-export interface AppEnv {}
+export type AppRouteArgs = [env: AppEnv, ctx: ExecutionContext];
 
-export type RouteArgs = [env: AppEnv, ctx: ExecutionContext];
+export type AppRouteHandler<TRequest extends AppRequest = AppRequest> = RouteHandler<TRequest, AppRouteArgs>;
+export type AppMiddleware<TRequest extends AppRequest = AppRequest> = AppRouteHandler<TRequest>;
 
-export function createRouter(options?: RouterOptions) {
-  return Router<AppRequest, RouteArgs>(options);
+export function createRouter<TRequest extends AppRequest = AppRequest>(options?: RouterOptions) {
+  return Router<TRequest, AppRouteArgs>(options);
 }
+
+export function createAuthenticatedRouter(options?: RouterOptions) {
+  const router = createRouter<AuthenticatedRequest>(options);
+  router.all("*", authMiddleware);
+  return router;
+}
+
+export type AuthenticatedRouteHandler = AppRouteHandler<AuthenticatedRequest>;
+export type AuthenticatedMiddleware = AppMiddleware<AuthenticatedRequest>;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,15 @@
+export type MaybePromise<T> = T | Promise<T>;
+
+export interface ErrorOptions {
+  cause?: unknown;
+}
+
+export class CustomError extends Error {
+  public cause?: unknown;
+
+  constructor(name: string, message?: string, options?: ErrorOptions) {
+    super(message);
+    this.name = name;
+    this.cause = options?.cause;
+  }
+}

--- a/src/utils/zod-date.ts
+++ b/src/utils/zod-date.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+export const ZodDate = z.preprocess(arg => {
+  if (typeof arg === "string" || arg instanceof Date) return new Date(arg);
+}, z.date());

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,25 @@
-name = "plantguard-api"
+name = "plantguard-api-dev"
 main = "src/index.ts"
 compatibility_date = "2023-10-27"
 
 workers_dev = false
 
+kv_namespaces = [
+  { binding = "users", id = "users", preview_id = "users" }
+]
+
 [env.staging]
+name = "plantguard-api-staging"
 route = { pattern = "plantguard-api-staging.dalbitresb.com", custom_domain = true }
 
+kv_namespaces = [
+  { binding = "users", id = "5e1f3151dcf5421b89069969d45a0aaf", preview_id = "users" }
+]
+
 [env.production]
+name = "plantguard-api-production"
 route = { pattern = "plantguard-api.dalbitresb.com", custom_domain = true }
+
+kv_namespaces = [
+  { binding = "users", id = "38543b8acb88408c90c2cc3c13399444", preview_id = "users" }
+]

--- a/yarn.lock
+++ b/yarn.lock
@@ -874,6 +874,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tsndr/cloudflare-worker-jwt@npm:^2.2.5":
+  version: 2.2.5
+  resolution: "@tsndr/cloudflare-worker-jwt@npm:2.2.5"
+  checksum: 58217c8424d423a7a62ab4e865de5fcf3b477a5b976812ba19c839794804b25791cf68c8f5585802f1c920e9318174a01bcbc4f12f0a853dc97372ce4ae154d8
+  languageName: node
+  linkType: hard
+
+"@types/bcryptjs@npm:^2.4.5":
+  version: 2.4.5
+  resolution: "@types/bcryptjs@npm:2.4.5"
+  checksum: a5c7989a67e882ea8bfb143c2be532b4eb2831f3cbc5315ea7172ac9ed999f2cc1887786721b657247e6de1e8c69c9b7ef714945f47f51dbb3154d107d4c3711
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^8.44.6":
   version: 8.44.6
   resolution: "@types/eslint@npm:8.44.6"
@@ -902,6 +916,13 @@ __metadata:
   version: 1.2.4
   resolution: "@types/minimist@npm:1.2.4"
   checksum: 01403652c09de17b8c6d7d9959cb7a244deccf31e9e7a1a7011fba73fa2724c14fe935718e0fdc48dcd30403fd76a916cb991d4c0ddf229748ccc6c4920c3371
+  languageName: node
+  linkType: hard
+
+"@types/ms@npm:^0.7.33":
+  version: 0.7.33
+  resolution: "@types/ms@npm:0.7.33"
+  checksum: ef610d94ebee838243af37800cb5d1a52b2ae0fb6880675fbb9276c0c4afcefda755f16889fa597ee4e5b377998a7e67b453614aae68d3225e5f7219984284df
   languageName: node
   linkType: hard
 
@@ -1264,6 +1285,13 @@ __metadata:
   version: 1.0.2
   resolution: "balanced-match@npm:1.0.2"
   checksum: 9308baf0a7e4838a82bbfd11e01b1cb0f0cf2893bc1676c27c2a8c0e70cbae1c59120c3268517a8ae7fb6376b4639ef81ca22582611dbee4ed28df945134aaee
+  languageName: node
+  linkType: hard
+
+"bcryptjs@npm:^2.4.3":
+  version: 2.4.3
+  resolution: "bcryptjs@npm:2.4.3"
+  checksum: b969467087ed7a01ff905a1c6a0c45014ec586248a448ea08370c8ed8bb314bda16a870ca23e0961d7d23bdce1a04c76fa70a9d680be814fa9ac7d8fc61870a3
   languageName: node
   linkType: hard
 
@@ -3324,7 +3352,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ms@npm:^2.0.0":
+"ms@npm:^2.0.0, ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
   checksum: d924b57e7312b3b63ad21fc5b3dc0af5e78d61a1fc7cfb5457edaf26326bf62be5307cc87ffb6862ef1c2b33b0233cdb5d4f01c4c958cc0d660948b65a287a48
@@ -3630,18 +3658,24 @@ __metadata:
     "@commitlint/cli": "npm:^18.2.0"
     "@commitlint/config-conventional": "npm:^18.1.0"
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.1.1"
+    "@tsndr/cloudflare-worker-jwt": "npm:^2.2.5"
+    "@types/bcryptjs": "npm:^2.4.5"
     "@types/eslint": "npm:^8.44.6"
+    "@types/ms": "npm:^0.7.33"
     "@typescript-eslint/eslint-plugin": "npm:^6.9.0"
     "@typescript-eslint/parser": "npm:^6.9.0"
+    bcryptjs: "npm:^2.4.3"
     concurrently: "npm:^8.2.2"
     eslint: "npm:^8.52.0"
     eslint-config-prettier: "npm:^9.0.0"
     eslint-plugin-unicorn: "npm:^48.0.1"
     itty-router: "npm:^4.0.23"
     lefthook: "npm:^1.5.2"
+    ms: "npm:^2.1.3"
     prettier: "npm:^3.0.3"
     typescript: "npm:^5.2.2"
     wrangler: "npm:^3.15.0"
+    zod: "npm:^3.22.4"
   languageName: unknown
   linkType: soft
 
@@ -4666,7 +4700,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.20.6":
+"zod@npm:^3.20.6, zod@npm:^3.22.4":
   version: 3.22.4
   resolution: "zod@npm:3.22.4"
   checksum: 7578ab283dac0eee66a0ad0fc4a7f28c43e6745aadb3a529f59a4b851aa10872b3890398b3160f257f4b6817b4ce643debdda4fb21a2c040adda7862cab0a587


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Added the initial implementation of the authentication services.

What's missing:

- Reset password
- Verification emails

Those two will be implemented in another PR.

### Usage

This service implemented 3 endpoints:

- `/api/v1/auth/register`: Allows registration of users. No email verification is required (for now).
	- `email`: string, must be a valid email
	- `password` : string, min: 8 chars, max: 72 chars
	- `fullName`: string
	- `preferredName`: string
- `/api/v1/auth/login`: Return a signed JWT token, valid for 30 days.
	- `email`: string, must be a valid email
	- `password` : string, min: 8 chars, max: 72 chars
- `/api/v1/users/me`: Return a `User` object for the JWT token. Requires sending the token in the `Authorization` header in the [Bearer format](https://swagger.io/docs/specification/authentication/bearer-authentication/).

### Why is it needed

All the routes should be protected with at least some basic security and RBAC.