### PR TITLE
chore: recreate KV namespaces and use wrangler default naming strategy

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,25 +1,23 @@
-name = "plantguard-api-dev"
+name = "plantguard-api"
 main = "src/index.ts"
 compatibility_date = "2023-10-27"
 
 workers_dev = false
 
 kv_namespaces = [
-  { binding = "users", id = "users", preview_id = "users" }
+  { binding = "users", id = "users" },
 ]
 
 [env.staging]
-name = "plantguard-api-staging"
 route = { pattern = "plantguard-api-staging.dalbitresb.com", custom_domain = true }
 
 kv_namespaces = [
-  { binding = "users", id = "5e1f3151dcf5421b89069969d45a0aaf", preview_id = "users" }
+  { binding = "users", id = "a0003162de054a9d89ded0b465c2fd09" },
 ]
 
 [env.production]
-name = "plantguard-api-production"
 route = { pattern = "plantguard-api.dalbitresb.com", custom_domain = true }
 
 kv_namespaces = [
-  { binding = "users", id = "38543b8acb88408c90c2cc3c13399444", preview_id = "users" }
+  { binding = "users", id = "df2d81c34e824e629692fd177ebd5d9c" },
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Normalizing worker service names with the default wrangler naming strategy. Also recreated KV namespaces but I was unable to create them using `wrangler kv:namespace create` since it seems to be bugged when using with environments.
