### PR TITLE
feat(devices): added initial impl of device registry service

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,5 @@
 import { authRouter } from "./auth/router";
+import { devicesRouter } from "./devices/router";
 import { usersRouter } from "./users/router";
 import { createRouter } from "./utils/router";
 
@@ -6,5 +7,6 @@ const router = createRouter({ base: "/api/v1" });
 
 router.all("/auth/*", authRouter.handle);
 router.all("/users/*", usersRouter.handle);
+router.all("/devices/*", devicesRouter.handle);
 
 export { router as routerV1 };

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,5 +1,6 @@
 import { authRouter } from "./auth/router";
 import { devicesRouter } from "./devices/router";
+import { pairRouter } from "./pair/router";
 import { usersRouter } from "./users/router";
 import { createRouter } from "./utils/router";
 
@@ -8,5 +9,6 @@ const router = createRouter({ base: "/api/v1" });
 router.all("/auth/*", authRouter.handle);
 router.all("/users/*", usersRouter.handle);
 router.all("/devices/*", devicesRouter.handle);
+router.all("/pair/*", pairRouter.handle);
 
 export { router as routerV1 };

--- a/src/devices/register-device.ts
+++ b/src/devices/register-device.ts
@@ -1,0 +1,29 @@
+import { StatusError } from "itty-router";
+
+import { Device, DeviceMetadata, DeviceRegistrationRequest } from "../models/device";
+import { User } from "../models/user";
+import { createDeviceKey, createSerialNumberKey } from "./utils";
+
+export async function registerDevice(db: KVNamespace, user: User, req: DeviceRegistrationRequest): Promise<Device> {
+  const serialNumberKey = createSerialNumberKey(req.serialNumber);
+  const possibleOwner = await db.get(serialNumberKey);
+  if (possibleOwner) {
+    throw new StatusError(400, "The serial number has already been registered");
+  }
+
+  const now = new Date();
+  const device: Device = {
+    ...req,
+    id: crypto.randomUUID(),
+    userId: user.id,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const metadata: DeviceMetadata = { name: device.name };
+  const deviceKey = createDeviceKey(user.id, device.id);
+
+  await db.put(deviceKey, JSON.stringify(device), { metadata });
+  await db.put(serialNumberKey, device.userId);
+
+  return device;
+}

--- a/src/devices/router.ts
+++ b/src/devices/router.ts
@@ -1,0 +1,128 @@
+import { json, StatusError } from "itty-router";
+
+import {
+  Device,
+  DeviceListQuery,
+  DeviceListResponse,
+  DeviceListResponseData,
+  DeviceMetadata,
+  DeviceRegistrationRequest,
+  DeviceUpdateRequest,
+} from "../models/device";
+import { assertModel, parseBody } from "../utils/model-parser";
+import { createAuthenticatedRouter } from "../utils/router";
+import { createDeviceKey, isValidDeviceId, parseDeviceKey } from "./utils";
+
+const router = createAuthenticatedRouter({ base: "/api/v1/devices" });
+
+router.get("/", async (request, env): Promise<DeviceListResponse> => {
+  const { limit, cursor = crypto.randomUUID() } = await assertModel(request.query, DeviceListQuery);
+
+  const results = await env.devices.list({ limit, cursor, prefix: request.user.id });
+  const data = results.keys.map<DeviceListResponseData>(key => {
+    const metadata = DeviceMetadata.parse(key.metadata);
+    const parsedKey = parseDeviceKey(key.name);
+    return {
+      id: parsedKey.deviceId,
+      name: metadata.name,
+    };
+  });
+
+  return {
+    data,
+    pagination: {
+      limit,
+      cursor,
+      complete: results.list_complete,
+    },
+  };
+});
+
+router.post("/", async (request, env) => {
+  const req = await parseBody(request, DeviceRegistrationRequest);
+
+  const possibleOwner = await env.devices.get(req.serialNumber);
+  if (possibleOwner) {
+    throw new StatusError(400, "The serial number has already been registered");
+  }
+
+  const now = new Date();
+  const device: Device = {
+    ...req,
+    id: crypto.randomUUID(),
+    userId: request.user.id,
+    createdAt: now,
+    updatedAt: now,
+  };
+  const metadata: DeviceMetadata = { name: device.name };
+  const key = createDeviceKey(request.user.id, device.id);
+
+  await env.devices.put(key, JSON.stringify(device), { metadata });
+  await env.devices.put(device.serialNumber, device.userId);
+
+  const headers = new Headers();
+  headers.set("Location", `/api/v1/devices/${device.id}`);
+  return json(device, { headers, status: 201 });
+});
+
+router.get("/:id", async (request, env): Promise<Device> => {
+  const { id } = request.params;
+  if (!isValidDeviceId(id)) {
+    throw new StatusError(400, "Invalid ID");
+  }
+
+  const key = createDeviceKey(request.user.id, id);
+  const device = await env.devices.get(key);
+  if (!device) {
+    throw new StatusError(404);
+  }
+
+  return Device.parse(device);
+});
+
+router.patch("/:id", async (request, env): Promise<Device> => {
+  const { id } = request.params;
+  if (!isValidDeviceId(id)) {
+    throw new StatusError(400, "Invalid ID");
+  }
+
+  const key = createDeviceKey(request.user.id, id);
+  const device = await env.devices.get(`${request.user.id}:${id}`);
+  if (!device) {
+    throw new StatusError(404);
+  }
+  const parsedDevice = Device.parse(device);
+
+  const req = await parseBody(request, DeviceUpdateRequest);
+  const updatedDevice: Device = {
+    ...parsedDevice,
+    ...req,
+    updatedAt: new Date(),
+  };
+  const updatedMetadata: DeviceMetadata = { name: updatedDevice.name };
+
+  await env.devices.put(key, JSON.stringify(updatedDevice), { metadata: updatedMetadata });
+
+  return updatedDevice;
+});
+
+router.delete("/:id", async (request, env) => {
+  const { id } = request.params;
+  if (!isValidDeviceId(id)) {
+    throw new StatusError(400, "Invalid ID");
+  }
+
+  const key = createDeviceKey(request.user.id, id);
+  const device = await env.devices.get(key);
+  if (!device) {
+    throw new StatusError(404);
+  }
+  const parsedDevice = Device.parse(device);
+
+  await env.devices.delete(key);
+  await env.devices.delete(parsedDevice.serialNumber);
+
+  return new Response(undefined, { status: 204 });
+});
+
+export { router as devicesRouter };

--- a/src/devices/router.ts
+++ b/src/devices/router.ts
@@ -1,4 +1,4 @@
-import { json, StatusError } from "itty-router";
+import { StatusError } from "itty-router";
 
 import {
   Device,
@@ -6,13 +6,11 @@ import {
   DeviceListResponse,
   DeviceListResponseData,
   DeviceMetadata,
-  DeviceRegistrationRequest,
   DeviceUpdateRequest,
 } from "../models/device";
 import { assertModel, parseBody } from "../utils/model-parser";
 import { PaginationMetadata } from "../utils/pagination";
 import { createAuthenticatedRouter } from "../utils/router";
-import { registerDevice } from "./register-device";
 import { createDeviceKey, createSerialNumberKey, isValidDeviceId, parseDeviceKey } from "./utils";
 
 const router = createAuthenticatedRouter({ base: "/api/v1/devices" });
@@ -43,16 +41,6 @@ router.get("/", async (request, env): Promise<DeviceListResponse> => {
       };
 
   return { data, pagination };
-});
-
-router.post("/", async (request, env) => {
-  const req = await parseBody(request, DeviceRegistrationRequest);
-
-  const device = await registerDevice(env.devices, request.user, req);
-
-  const headers = new Headers();
-  headers.set("Location", `/api/v1/devices/${device.id}`);
-  return json(device, { headers, status: 201 });
 });
 
 router.get("/:id", async (request, env): Promise<Device> => {

--- a/src/devices/router.ts
+++ b/src/devices/router.ts
@@ -16,7 +16,7 @@ import { createDeviceKey, isValidDeviceId, parseDeviceKey } from "./utils";
 const router = createAuthenticatedRouter({ base: "/api/v1/devices" });
 
 router.get("/", async (request, env): Promise<DeviceListResponse> => {
-  const { limit, cursor = crypto.randomUUID() } = await assertModel(request.query, DeviceListQuery);
+  const { limit, cursor } = await assertModel(request.query, DeviceListQuery);
 
   const results = await env.devices.list({ limit, cursor, prefix: request.user.id });
   const data = results.keys.map<DeviceListResponseData>(key => {

--- a/src/devices/utils.ts
+++ b/src/devices/utils.ts
@@ -1,32 +1,27 @@
 import { StatusError } from "itty-router";
 
 import { Device } from "../models/device";
-
-const separator = ":";
+import { createKey, splitKey } from "../utils/kv-keys";
 
 interface DeviceKey {
   userId: string;
   deviceId: string;
 }
 
-function createKey(values: string[]) {
-  return values.join(separator);
-}
-
-export const deviceKeyPrefix = "device";
+const deviceKeyPrefix = "device";
 
 export function createDeviceKey(userId: string, deviceId: string): string {
   return createKey([deviceKeyPrefix, userId, deviceId]);
 }
 
-export const serialNumberKeyPrefix = "serial";
+const serialNumberKeyPrefix = "serial";
 
 export function createSerialNumberKey(serialNumber: string): string {
   return createKey([serialNumberKeyPrefix, serialNumber]);
 }
 
 export function parseDeviceKey(key: string): DeviceKey {
-  const split = key.split(separator);
+  const split = splitKey(key);
   if (split[0] !== deviceKeyPrefix) {
     throw new StatusError(500, `Found an invalid prefix while parsing a device key: ${split[0]}`);
   }

--- a/src/devices/utils.ts
+++ b/src/devices/utils.ts
@@ -1,3 +1,5 @@
+import { StatusError } from "itty-router";
+
 import { Device } from "../models/device";
 
 const separator = ":";
@@ -7,15 +9,30 @@ interface DeviceKey {
   deviceId: string;
 }
 
+function createKey(values: string[]) {
+  return values.join(separator);
+}
+
+export const deviceKeyPrefix = "device";
+
 export function createDeviceKey(userId: string, deviceId: string): string {
-  return `${userId}${separator}${deviceId}`;
+  return createKey([deviceKeyPrefix, userId, deviceId]);
+}
+
+export const serialNumberKeyPrefix = "serial";
+
+export function createSerialNumberKey(serialNumber: string): string {
+  return createKey([serialNumberKeyPrefix, serialNumber]);
 }
 
 export function parseDeviceKey(key: string): DeviceKey {
   const split = key.split(separator);
+  if (split[0] !== deviceKeyPrefix) {
+    throw new StatusError(500, `Found an invalid prefix while parsing a device key: ${split[0]}`);
+  }
   return {
-    userId: split[0],
-    deviceId: split[1],
+    userId: split[1],
+    deviceId: split[2],
   };
 }
 

--- a/src/devices/utils.ts
+++ b/src/devices/utils.ts
@@ -1,0 +1,25 @@
+import { Device } from "../models/device";
+
+const separator = ":";
+
+interface DeviceKey {
+  userId: string;
+  deviceId: string;
+}
+
+export function createDeviceKey(userId: string, deviceId: string): string {
+  return `${userId}${separator}${deviceId}`;
+}
+
+export function parseDeviceKey(key: string): DeviceKey {
+  const split = key.split(separator);
+  return {
+    userId: split[0],
+    deviceId: split[1],
+  };
+}
+
+export function isValidDeviceId(id: string): boolean {
+  const result = Device.shape.id.safeParse(id);
+  return result.success;
+}

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -17,8 +17,11 @@ export const DeviceMetadata = Device.pick({ name: true });
 export type DeviceMetadata = z.infer<typeof DeviceMetadata>;
 
 export const DeviceListQuery = z.object({
-  limit: z.number().min(1).max(50),
-  cursor: z.string().optional(),
+  limit: z.number().min(1).max(50).optional().default(10),
+  cursor: z
+    .string()
+    .optional()
+    .default(() => crypto.randomUUID()),
 });
 export type DeviceListQuery = z.infer<typeof DeviceListQuery>;
 

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -17,7 +17,7 @@ export const DeviceMetadata = Device.pick({ name: true });
 export type DeviceMetadata = z.infer<typeof DeviceMetadata>;
 
 export const DeviceListQuery = z.object({
-  limit: z.number().min(1).max(50).optional().default(10),
+  limit: z.coerce.number().min(1).max(50).optional().default(10),
   cursor: z.string().optional(),
 });
 export type DeviceListQuery = z.infer<typeof DeviceListQuery>;

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+import { ZodDate } from "../utils/zod-date";
+
+export const Device = z.object({
+  id: z.string().uuid(),
+  ownerId: z.string().uuid(),
+  name: z.string().min(1),
+  serialNumber: z.string(),
+  createdAt: ZodDate,
+  updatedAt: ZodDate,
+});
+export type Device = z.infer<typeof Device>;

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -1,13 +1,41 @@
 import { z } from "zod";
 
+import { PaginationMetadata } from "../utils/pagination";
 import { ZodDate } from "../utils/zod-date";
 
 export const Device = z.object({
   id: z.string().uuid(),
-  ownerId: z.string().uuid(),
-  name: z.string().min(1),
-  serialNumber: z.string(),
+  userId: z.string().uuid(),
+  name: z.string().min(1).max(50),
+  serialNumber: z.string().regex(/\d{4}-\d{4}-\d{2}/g),
   createdAt: ZodDate,
   updatedAt: ZodDate,
 });
 export type Device = z.infer<typeof Device>;
+
+export const DeviceMetadata = Device.pick({ name: true });
+export type DeviceMetadata = z.infer<typeof DeviceMetadata>;
+
+export const DeviceListQuery = z.object({
+  limit: z.number().min(1).max(50),
+  cursor: z.string().optional(),
+});
+export type DeviceListQuery = z.infer<typeof DeviceListQuery>;
+
+export const DeviceListResponseData = Device.pick({ id: true, name: true });
+export type DeviceListResponseData = z.infer<typeof DeviceListResponseData>;
+
+export const DeviceListResponse = z.object({
+  data: z.array(DeviceMetadata),
+  pagination: PaginationMetadata,
+});
+export type DeviceListResponse = z.infer<typeof DeviceListResponse>;
+
+export const DeviceRegistrationRequest = Device.pick({
+  name: true,
+  serialNumber: true,
+});
+export type DeviceRegistrationRequest = z.infer<typeof DeviceRegistrationRequest>;
+
+export const DeviceUpdateRequest = Device.pick({ name: true }).partial();
+export type DeviceUpdateRequest = z.infer<typeof DeviceUpdateRequest>;

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -18,10 +18,7 @@ export type DeviceMetadata = z.infer<typeof DeviceMetadata>;
 
 export const DeviceListQuery = z.object({
   limit: z.number().min(1).max(50).optional().default(10),
-  cursor: z
-    .string()
-    .optional()
-    .default(() => crypto.randomUUID()),
+  cursor: z.string().optional(),
 });
 export type DeviceListQuery = z.infer<typeof DeviceListQuery>;
 

--- a/src/models/device.ts
+++ b/src/models/device.ts
@@ -39,3 +39,44 @@ export type DeviceRegistrationRequest = z.infer<typeof DeviceRegistrationRequest
 
 export const DeviceUpdateRequest = Device.pick({ name: true }).partial();
 export type DeviceUpdateRequest = z.infer<typeof DeviceUpdateRequest>;
+
+export const DevicePairRequest = Device.pick({ serialNumber: true }).extend({
+  code: z
+    .string()
+    .min(6)
+    .max(6)
+    .regex(/^\d{6}$/g),
+  secret: z.string(),
+  jwt: z.string().optional(),
+  expirationTtl: z.number().max(600).optional().default(300),
+});
+export type DevicePairRequest = z.infer<typeof DevicePairRequest>;
+
+export const DevicePairInitRequest = DevicePairRequest.pick({
+  serialNumber: true,
+  expirationTtl: true,
+});
+export type DevicePairInitRequest = z.infer<typeof DevicePairInitRequest>;
+
+export const DevicePairInitResponse = DevicePairRequest.pick({
+  code: true,
+  secret: true,
+});
+export type DevicePairInitResponse = z.infer<typeof DevicePairInitResponse>;
+
+export const DevicePairFindQuery = DevicePairRequest.pick({ code: true });
+export type DevicePairFindQuery = z.infer<typeof DevicePairFindQuery>;
+
+export const DevicePairFindResponse = DevicePairRequest.pick({ code: true, serialNumber: true });
+export type DevicePairFindResponse = z.infer<typeof DevicePairFindResponse>;
+
+export const DevicePairCheckRequest = DevicePairRequest.pick({ code: true, secret: true });
+export type DevicePairCheckRequest = z.infer<typeof DevicePairCheckRequest>;
+
+export const DevicePairCheckResponse = DevicePairRequest.pick({ jwt: true });
+export type DevicePairCheckResponse = z.infer<typeof DevicePairCheckResponse>;
+
+export const DevicePairConfirmRequest = DevicePairRequest.pick({ code: true }).extend({
+  name: Device.shape.name,
+});
+export type DevicePairConfirmRequest = z.infer<typeof DevicePairConfirmRequest>;

--- a/src/pair/router.ts
+++ b/src/pair/router.ts
@@ -1,0 +1,116 @@
+import { json, StatusError } from "itty-router";
+
+import { authMiddleware } from "../auth/middleware";
+import { registerDevice } from "../devices/register-device";
+import { createSerialNumberKey } from "../devices/utils";
+import {
+  DevicePairCheckRequest,
+  DevicePairCheckResponse,
+  DevicePairConfirmRequest,
+  DevicePairFindQuery,
+  DevicePairFindResponse,
+  DevicePairInitRequest,
+  DevicePairInitResponse,
+  DevicePairRequest,
+} from "../models/device";
+import { assertModel, parseBody } from "../utils/model-parser";
+import { createRouter } from "../utils/router";
+import { createPairKey, generatePairResponse } from "./utils";
+
+const router = createRouter({ base: "/api/v1/pair" });
+
+router.post("/init", async (request, env): Promise<DevicePairInitResponse> => {
+  const req = await parseBody(request, DevicePairInitRequest);
+  const serialNumberKey = createSerialNumberKey(req.serialNumber);
+
+  const possibleOwner = await env.devices.get(serialNumberKey);
+  if (possibleOwner) {
+    throw new StatusError(400, "The serial number has already been registered");
+  }
+
+  const { code, secret } = generatePairResponse();
+  const pairKey = createPairKey(code);
+  const pairRequest: DevicePairRequest = { ...req, code, secret };
+
+  await env.devices.put(pairKey, JSON.stringify(pairRequest), { expirationTtl: req.expirationTtl });
+
+  return { code, secret };
+});
+
+router.get("/find", authMiddleware, async (request, env): Promise<DevicePairFindResponse> => {
+  const query = await assertModel(request.query, DevicePairFindQuery);
+  const pairKey = createPairKey(query.code);
+
+  const value = await env.devices.get(pairKey);
+  if (!value) {
+    throw new StatusError(404);
+  }
+  const pairRequest = DevicePairRequest.parse(JSON.parse(value));
+
+  if (pairRequest.jwt) {
+    throw new StatusError(400, "This device has already been paired");
+  }
+
+  return { code: query.code, serialNumber: pairRequest.serialNumber };
+});
+
+router.post("/check", async (request, env) => {
+  const req = await parseBody(request, DevicePairCheckRequest);
+  const pairKey = createPairKey(req.code);
+
+  const value = await env.devices.get(pairKey);
+  if (!value) {
+    throw new StatusError(404);
+  }
+  const pairRequest = DevicePairRequest.parse(JSON.parse(value));
+
+  if (req.secret !== pairRequest.secret) {
+    throw new StatusError(401);
+  }
+
+  if (pairRequest.jwt) {
+    const response: DevicePairCheckResponse = { jwt: pairRequest.jwt };
+    return response;
+  }
+
+  return new Response(undefined, { status: 204 });
+});
+
+router.post("/confirm", authMiddleware, async (request, env) => {
+  // This is safe to override because the auth middleware will make sure
+  // we only get here when a valid login is available
+  const user = request.user!;
+
+  const req = await parseBody(request, DevicePairConfirmRequest);
+  const pairKey = createPairKey(req.code);
+
+  const value = await env.devices.get(pairKey);
+  if (!value) {
+    throw new StatusError(404);
+  }
+  const pairRequest = DevicePairRequest.parse(JSON.parse(value));
+
+  if (pairRequest.jwt) {
+    throw new StatusError(400, "This device has already been paired");
+  }
+
+  const jwt = await env.jwt.sign({
+    sub: user.id,
+    name: user.fullName,
+    email: user.email,
+  });
+
+  pairRequest.jwt = jwt;
+  await env.devices.put(pairKey, JSON.stringify(pairRequest), { expirationTtl: pairRequest.expirationTtl });
+
+  const device = await registerDevice(env.devices, user, {
+    name: req.name,
+    serialNumber: pairRequest.serialNumber,
+  });
+
+  const headers = new Headers();
+  headers.set("Location", `/api/v1/devices/${device.id}`);
+  return json(device, { headers, status: 201 });
+});
+
+export { router as pairRouter };

--- a/src/pair/utils.ts
+++ b/src/pair/utils.ts
@@ -1,0 +1,15 @@
+import { DevicePairInitResponse } from "../models/device";
+import { generateRandomBytes } from "../utils/crypto";
+import { createKey } from "../utils/kv-keys";
+
+const pairKeyPrefix = "pair";
+
+export function createPairKey(pairCode: string): string {
+  return createKey([pairKeyPrefix, pairCode]);
+}
+
+export function generatePairResponse(): DevicePairInitResponse {
+  const code = generateRandomBytes(6, byte => `${byte % 10}`);
+  const secret = generateRandomBytes(32, byte => byte.toString(16).padStart(2, "0"));
+  return { code, secret };
+}

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,0 +1,7 @@
+export type GenerateRandomBytesTransformer = (byte: number) => string;
+
+export function generateRandomBytes(size: number, transformer: GenerateRandomBytesTransformer): string {
+  const buffer = new Uint8Array(size);
+  crypto.getRandomValues(buffer);
+  return [...buffer].map(byte => transformer(byte)).join("");
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -17,6 +17,7 @@ export interface AppBindings {
   JWT_SECRET: string;
   // KV
   users: KVNamespace;
+  devices: KVNamespace;
 }
 
 export interface AppEnv extends AppBindings {

--- a/src/utils/kv-keys.ts
+++ b/src/utils/kv-keys.ts
@@ -1,0 +1,9 @@
+const separator = ":";
+
+export function createKey(values: string[]) {
+  return values.join(separator);
+}
+
+export function splitKey(key: string) {
+  return key.split(separator);
+}

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,8 +1,16 @@
 import { z } from "zod";
 
-export const PaginationMetadata = z.object({
+const PaginationMetadataBase = z.object({
   limit: z.number(),
-  cursor: z.string(),
-  complete: z.boolean(),
+  complete: z.literal(true),
 });
+type PaginationMetadataBase = z.infer<typeof PaginationMetadataBase>;
+
+const PaginationMetadataWithCursor = PaginationMetadataBase.extend({
+  complete: z.literal(false),
+  cursor: z.string(),
+});
+type PaginationMetadataWithCursor = z.infer<typeof PaginationMetadataWithCursor>;
+
+export const PaginationMetadata = z.union([PaginationMetadataBase, PaginationMetadataWithCursor]);
 export type PaginationMetadata = z.infer<typeof PaginationMetadata>;

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+
+export const PaginationMetadata = z.object({
+  limit: z.number(),
+  cursor: z.string(),
+  complete: z.boolean(),
+});
+export type PaginationMetadata = z.infer<typeof PaginationMetadata>;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -6,6 +6,7 @@ workers_dev = false
 
 kv_namespaces = [
   { binding = "users", id = "users" },
+  { binding = "devices", id = "devices" },
 ]
 
 [env.staging]
@@ -13,6 +14,7 @@ route = { pattern = "plantguard-api-staging.dalbitresb.com", custom_domain = tru
 
 kv_namespaces = [
   { binding = "users", id = "a0003162de054a9d89ded0b465c2fd09" },
+  { binding = "devices", id = "d81daa0724494d5cbb5201b02d22229b" },
 ]
 
 [env.production]
@@ -20,4 +22,5 @@ route = { pattern = "plantguard-api.dalbitresb.com", custom_domain = true }
 
 kv_namespaces = [
   { binding = "users", id = "df2d81c34e824e629692fd177ebd5d9c" },
+  { binding = "devices", id = "7328c0185ae84f2ca0068931bb9e04d2" },
 ]


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--
Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.
https://guides.github.com/features/mastering-markdown/
-->

### What does it do

Added the initial implementation of the device registry services.

#### What's missing:

- Device authentication

Those will be implemented in another PR.

### Usage

This service implemented 5 endpoints. All the endpoints expect to receive an authentication token in the `Authorization` header using the [Bearer format](https://swagger.io/docs/specification/authentication/bearer-authentication/).

- `GET /api/v1/devices`: Lists all the registered `Device`s for the current `User`. It accepts the following query parameters:
	- `limit`: number, min: 1, max: 50, optional
	- `cursor` : string, optional
- `GET /api/v1/devices/:id`: Get a `Device` by ID. It has the following route parameters:
	- `id`: string, must be valid UUID
- `PATCH /api/v1/devices/:id`: Updates an existing `Device` for the current `User`
	- Route parameters
		- `id`: string, must be valid UUID
	- Body, serialized as JSON
		- `name`: string, min: 1 char, max: 50 chars, optional
- `DELETE /api/v1/devices/:id`: Get a `Device` by ID. It has the following route parameters:
	- `id`: string, must be valid UUID

It also implemented 4 additional endpoints to be used with the IoT devices:

- `POST /api/v1/pair/init`: Initializes a `Device` pairing process
	- Body
		- `serialNumber`: string, must match the following RegEx: `/\d{4}-\d{4}-\d{2}/g`
		- `expirationTtl` : number, max: 600, default: 300
	- Response
		- `code`: string, 6 digits, to be shown to users from the IoT device's screen
		- `secret`: string, 64 chars, to be used to validate the IoT device in the check endpoint
- `GET /api/v1/pair/find`: Allows searching by pairing code
	- Headers
		- `Authorization` header using the [Bearer format](https://swagger.io/docs/specification/authentication/bearer-authentication/)
	- Query parameters
		- `code`: string, 6 digits
	- Response
		- `code`: string, 6 digits
		- `serialNumber`: string, matches the following RegEx: `/\d{4}-\d{4}-\d{2}/g`
- `POST /api/v1/pair/check`: Checks if the `Device` has already been authenticated by the `User`
	- Body
		- `code`: string, 6 digits
		- `secret`: string, 64 chars
	- Response
		- If the `User` has not yet authorized the `Device`, the server will return a `204 No content` response with an empty body.
		- If the `User` has already authorized the `Device`, the server will return
			- `jwt`: string, the IoT device should save this token to use it with authenticated endpoints
- `POST /api/v1/pair/confirm`: Authorizes a `Device` in the current `User` account
	- Headers
		- `Authorization` header using the [Bearer format](https://swagger.io/docs/specification/authentication/bearer-authentication/)
	- Body
		- `code`: string, 6 digits
		- `name`: string, min: 1 char, max: 50 chars

### Why is it needed

This service will be used to register new devices in the system to start receiving data from the sensors.